### PR TITLE
Librerias de Android actualizadas

### DIFF
--- a/android/app/src/main/java/com/targetapp/MainApplication.java
+++ b/android/app/src/main/java/com/targetapp/MainApplication.java
@@ -5,17 +5,13 @@ package com.targetapp;
 import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.Assurance;
 import com.adobe.marketing.mobile.Extension;
-import com.adobe.marketing.mobile.edge.identity.Identity;
+import com.adobe.marketing.mobile.Identity;
 import com.adobe.marketing.mobile.Lifecycle;
 import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.Signal;
-import com.adobe.marketing.mobile.Edge;
 import com.adobe.marketing.mobile.Target;
-
-
-
-//import com.adobe.marketing.mobile.edge.consent.Consent;
+import com.adobe.marketing.mobile.UserProfile;
 
 import android.app.Application;
 import android.content.Context;
@@ -84,12 +80,12 @@ public class MainApplication extends Application implements ReactApplication {
     MobileCore.setLogLevel(LoggingMode.DEBUG);
     MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID);
     List<Class<? extends Extension>> extensions = Arrays.asList(
+            Assurance.EXTENSION,
+            Target.EXTENSION,
+            Identity.EXTENSION,
             Lifecycle.EXTENSION,
             Signal.EXTENSION,
-            Identity.EXTENSION,
-            Edge.EXTENSION,
-            Target.EXTENSION,
-            Assurance.EXTENSION
+            UserProfile.EXTENSION
             );
     MobileCore.registerExtensions(extensions, o -> {
         Log.d("LOG_TAG", "AEP Mobile SDK is initialized");

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   "dependencies": {
     "@adobe/react-native-aepassurance": "^4.0.0",
     "@adobe/react-native-aepcore": "^2.0.0",
-    "@adobe/react-native-aepedge": "^2.0.0",
-    "@adobe/react-native-aepedgeidentity": "^2.0.0",
     "@adobe/react-native-aeptarget": "^2.0.0",
+    "@adobe/react-native-aepuserprofile": "^2.0.0",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "react": "18.1.0",


### PR DESCRIPTION
Quite algunas librerias que no eran necesarias y agregue las que son requeridas.

Usando el siguiente comando pude abrir la sesión de Assurance:

npx uri-scheme open targetapp://home?adb_validation_sessionid=5b98b166-b555-49f9-bacd-88d6c55da9f7 --android

Y en ella puedes ver los eventos TargetPrefetchRequest y TargetPrefetchResponse